### PR TITLE
Add array constructor from allocator

### DIFF
--- a/include/zisa/memory/array_decl.hpp
+++ b/include/zisa/memory/array_decl.hpp
@@ -44,6 +44,7 @@ public:
   array(T *raw_ptr, const shape_type &shape);
   explicit array(const shape_type &shape,
                  device_type device = device_type::cpu);
+  array(const shape_type &shape, const allocator<T> &alloc);
 
   array &operator=(const array &) = default;
   array &operator=(array &&) noexcept = default;

--- a/include/zisa/memory/array_impl.hpp
+++ b/include/zisa/memory/array_impl.hpp
@@ -20,6 +20,10 @@ array<T, n_dims, Indexing>::array(const shape_type &shape, device_type device)
     : super(shape, contiguous_memory<T>(product(shape), device)) {}
 
 template <class T, int n_dims, template <int N> class Indexing>
+array<T, n_dims, Indexing>::array(const shape_type &shape, const allocator<T> &alloc)
+    : super(shape, contiguous_memory<T>(product(shape), alloc)) {}
+
+template <class T, int n_dims, template <int N> class Indexing>
 array<T, n_dims, Indexing>::array(
     const array_const_view<T, n_dims, Indexing> &other)
     : super(shape, contiguous_memory<T>(product(other.shape()))) {


### PR DESCRIPTION
Adding a constructor to the array class in order to explicitly pass an allocator. Enables using custom memory resources.